### PR TITLE
add ability to set registry, repository and tag values and support private registries

### DIFF
--- a/charts/nango/templates/jobs/jobs-deployment.yaml
+++ b/charts/nango/templates/jobs/jobs-deployment.yaml
@@ -13,9 +13,13 @@ spec:
       labels:
         app: {{ .Values.jobs.name | default "nango-jobs" }}
     spec:
+      {{- with .Values.shared.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Values.jobs.name | default "nango-jobs" }}
-          image: nangohq/nango:prod-{{ .Values.jobs.tag | default .Values.shared.tag }}
+          image: {{ .Values.shared.imageRegistry | default "nangohq" }}/{{ .Values.shared.imageRepository | default "nango" }}:{{ .Values.jobs.tag | default .Values.shared.tag }}
           imagePullPolicy: {{ .Values.imagePullPolicy | default "Always" }}
           args: ["node", "packages/jobs/dist/app.js"]
           env:

--- a/charts/nango/templates/orchestrator/orchestrator-deployment.yaml
+++ b/charts/nango/templates/orchestrator/orchestrator-deployment.yaml
@@ -13,9 +13,13 @@ spec:
       labels:
         app: {{ .Values.orchestrator.name | default "nango-orchestrator" }}
     spec:
+      {{- with .Values.shared.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Values.orchestrator.name | default "nango-orchestrator" }}
-          image: nangohq/nango:prod-{{ .Values.orchestrator.tag | default .Values.shared.tag }}
+          image: {{ .Values.shared.imageRegistry | default "nangohq" }}/{{ .Values.shared.imageRepository | default "nango" }}:{{ .Values.orchestrator.tag | default .Values.shared.tag }}
           imagePullPolicy: {{ .Values.imagePullPolicy | default "Always" }}
           args: ["node", "packages/orchestrator/dist/app.js"]
           env:

--- a/charts/nango/templates/persist/persist-deployment.yaml
+++ b/charts/nango/templates/persist/persist-deployment.yaml
@@ -13,9 +13,13 @@ spec:
       labels:
         app: {{ .Values.persist.name | default "nango-persist" }}
     spec:
+      {{- with .Values.shared.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Values.persist.name | default "nango-persist" }}
-          image: nangohq/nango:prod-{{ .Values.persist.tag | default .Values.shared.tag }}
+          image: {{ .Values.shared.imageRegistry | default "nangohq" }}/{{ .Values.shared.imageRepository | default "nango" }}:{{ .Values.persist.tag | default .Values.shared.tag }}
           imagePullPolicy: {{ .Values.imagePullPolicy | default "Always" }}
           args: ["node", "packages/persist/dist/app.js"]
           env:

--- a/charts/nango/templates/runner/runner-deployment.yaml
+++ b/charts/nango/templates/runner/runner-deployment.yaml
@@ -13,9 +13,13 @@ spec:
       labels:
         app: {{ .Values.runner.name | default "nango-runner" }}
     spec:
+      {{- with .Values.shared.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Values.runner.name | default "nango-runner" }}
-          image: nangohq/nango:prod-{{ .Values.runner.tag | default .Values.shared.tag }}
+          image: {{ .Values.shared.imageRegistry | default "nangohq" }}/{{ .Values.shared.imageRepository | default "nango" }}:{{ .Values.runner.tag | default .Values.shared.tag }}
           imagePullPolicy: {{ .Values.imagePullPolicy | default "Always" }}
           args: ["node", "packages/runner/dist/app.js"]
           env:

--- a/charts/nango/templates/server/server-deployment.yaml
+++ b/charts/nango/templates/server/server-deployment.yaml
@@ -13,9 +13,13 @@ spec:
       labels:
         app: {{ .Values.server.name | default "nango-server" }}
     spec:
+      {{- with .Values.shared.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Values.server.name | default "nango-server" }}
-          image: nangohq/nango:prod-{{ .Values.server.tag | default .Values.shared.tag }}
+          image: {{ .Values.shared.imageRegistry | default "nangohq" }}/{{ .Values.shared.imageRepository | default "nango" }}:{{ .Values.server.tag | default .Values.shared.tag }}
           imagePullPolicy: {{ .Values.imagePullPolicy  | default "Always" }}
           args: ["node", "packages/server/dist/server.js"]
           ports:

--- a/charts/nango/values.yaml
+++ b/charts/nango/values.yaml
@@ -81,4 +81,4 @@ shared:
   NANGO_LOGS_ES_PWD: nango
   NANGO_LOGS_ES_URL: https://nango-elasticsearch.default.svc.cluster.local:9200
   NANGO_LOGS_ES_USER: elastic
-  tag: 23dd7e17fa32a0c23cabfb34cceecf30b293d38a # 2024/12/23
+  tag: prod-23dd7e17fa32a0c23cabfb34cceecf30b293d38a # 2024/12/23

--- a/example-values.yaml
+++ b/example-values.yaml
@@ -90,4 +90,4 @@ shared:
   NANGO_LOGS_ES_PWD: nango
   NANGO_LOGS_ES_URL: https://nango-elasticsearch.default.svc.cluster.local:9200
   NANGO_LOGS_ES_USER: elastic
-  tag: 23dd7e17fa32a0c23cabfb34cceecf30b293d38a
+  tag: prod-23dd7e17fa32a0c23cabfb34cceecf30b293d38a


### PR DESCRIPTION
Particular enterprise customers may require that images be pulled from private registries that require authentication.

This PR allows that.

This PR also moves away from prefixing tags with `prod-` which seemed to be an intentional choice but (my opinion) would be worth review. I _guess_ anyone wanting to utilize an image that they have tagged themselves _could_ prefix their own images with `-prod` but it would be unlikely they'd want to.