### PR TITLE
add support for nodeSelectors

### DIFF
--- a/charts/nango/Chart.yaml
+++ b/charts/nango/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: nango
 type: application
-version: 1.0.2
+version: 1.0.3
 appVersion: 0.0.2
 dependencies:
   - condition: postgresql.enabled

--- a/charts/nango/templates/jobs/jobs-deployment.yaml
+++ b/charts/nango/templates/jobs/jobs-deployment.yaml
@@ -17,6 +17,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.jobs.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Values.jobs.name | default "nango-jobs" }}
           image: {{ .Values.shared.imageRegistry | default "nangohq" }}/{{ .Values.shared.imageRepository | default "nango" }}:{{ .Values.jobs.tag | default .Values.shared.tag }}

--- a/charts/nango/templates/orchestrator/orchestrator-deployment.yaml
+++ b/charts/nango/templates/orchestrator/orchestrator-deployment.yaml
@@ -17,6 +17,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.orchestrator.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Values.orchestrator.name | default "nango-orchestrator" }}
           image: {{ .Values.shared.imageRegistry | default "nangohq" }}/{{ .Values.shared.imageRepository | default "nango" }}:{{ .Values.orchestrator.tag | default .Values.shared.tag }}

--- a/charts/nango/templates/persist/persist-deployment.yaml
+++ b/charts/nango/templates/persist/persist-deployment.yaml
@@ -17,6 +17,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.persist.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Values.persist.name | default "nango-persist" }}
           image: {{ .Values.shared.imageRegistry | default "nangohq" }}/{{ .Values.shared.imageRepository | default "nango" }}:{{ .Values.persist.tag | default .Values.shared.tag }}

--- a/charts/nango/templates/runner/runner-deployment.yaml
+++ b/charts/nango/templates/runner/runner-deployment.yaml
@@ -17,6 +17,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.runner.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Values.runner.name | default "nango-runner" }}
           image: {{ .Values.shared.imageRegistry | default "nangohq" }}/{{ .Values.shared.imageRepository | default "nango" }}:{{ .Values.runner.tag | default .Values.shared.tag }}

--- a/charts/nango/templates/server/server-deployment.yaml
+++ b/charts/nango/templates/server/server-deployment.yaml
@@ -17,6 +17,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.server.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Values.server.name | default "nango-server" }}
           image: {{ .Values.shared.imageRegistry | default "nangohq" }}/{{ .Values.shared.imageRepository | default "nango" }}:{{ .Values.server.tag | default .Values.shared.tag }}


### PR DESCRIPTION
This pull request adds support for the `nodeSelector` to allow pods to target specific nodes for scheduling - according to [kubernetes documentation this is "is the simplest way to constrain Pods to nodes with specific labels"](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity).

To confirm the proper operation of the resulting helm chart I (temporarily) modified the values.yaml file to include some configuration _with_ `nodeSelector` set and others set with two values. The resulting kubernetes manifests appear to be valid (human review), are shown as valid when reviewed by AI. The output is below where "server" was the component with no `nodeSelector` value:

```shell
helm template . --values values.yaml | grep -A18 'kind: Deployment'
kind: Deployment
metadata:
  namespace: default
  name: jobs
spec:
  replicas: 1
  selector:
    matchLabels:
      app: jobs 
  template:
    metadata:
      labels:
        app: jobs
    spec:
      nodeSelector:
        kubernetes.io/arch: amd64
      containers:
        - name: jobs
          image: nangohq/nango:prod-23dd7e17fa32a0c23cabfb34cceecf30b293d38a
--
kind: Deployment
metadata:
  namespace: default
  name: orchestrator
spec:
  replicas: 1
  selector:
    matchLabels:
      app: orchestrator
  template:
    metadata:
      labels:
        app: orchestrator
    spec:
      nodeSelector:
        kubernetes.io/arch: amd64
        kubernetes.io/os: linux
      containers:
        - name: orchestrator
--
kind: Deployment
metadata:
  namespace: default
  name: persist
spec:
  replicas: 1
  selector:
    matchLabels:
      app: persist
  template:
    metadata:
      labels:
        app: persist
    spec:
      nodeSelector:
        kubernetes.io/arch: amd64
        kubernetes.io/os: linux
      containers:
        - name: persist
--
kind: Deployment
metadata:
  namespace: default
  name: runner
spec:
  replicas: 1
  selector:
    matchLabels:
      app: runner 
  template:
    metadata:
      labels:
        app: runner
    spec:
      nodeSelector:
        kubernetes.io/arch: amd64
        kubernetes.io/os: linux
      containers:
        - name: runner
--
kind: Deployment
metadata:
  namespace: default
  name: server
spec:
  replicas: 1
  selector: 
    matchLabels:
      app: server
  template:
    metadata:
      labels:
        app: server
    spec:
      containers:
        - name: server
          image: nangohq/nango:prod-23dd7e17fa32a0c23cabfb34cceecf30b293d38a
          imagePullPolicy: Always
          args: ["node", "packages/server/dist/server.js"]
```