### PR TITLE
fix: remove prod tag from docker image

### DIFF
--- a/charts/nango/values.yaml
+++ b/charts/nango/values.yaml
@@ -81,4 +81,4 @@ shared:
   NANGO_LOGS_ES_PWD: nango
   NANGO_LOGS_ES_URL: https://nango-elasticsearch.default.svc.cluster.local:9200
   NANGO_LOGS_ES_USER: elastic
-  tag: prod-23dd7e17fa32a0c23cabfb34cceecf30b293d38a # 2024/12/23
+  tag: 8e1afd4f9c1a48112b87c75ae6699debdb8f1a48 # 2025/02/10


### PR DESCRIPTION
This tag does not exists anymore 
