### PR TITLE
fix: fixes to templates and values to make first-time deploy work wit…

### DIFF
--- a/charts/nango/Chart.yaml
+++ b/charts/nango/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: nango
 type: application
-version: 1.0.4
+version: 1.0.5
 appVersion: 0.0.2
 dependencies:
   - condition: postgresql.enabled

--- a/charts/nango/templates/jobs/jobs-pvc.yaml
+++ b/charts/nango/templates/jobs/jobs-pvc.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.jobs.volume.claimName }}
   namespace: {{ .Values.shared.namespace }}
 spec:
-  storageClassName: {{ .Values.jobs.volume.claimName }}
+  storageClassName: {{ .Values.jobs.volume.storageClassName }}
   accessModes:
   - ReadWriteOnce
   resources:

--- a/charts/nango/templates/runner/runner-deployment.yaml
+++ b/charts/nango/templates/runner/runner-deployment.yaml
@@ -31,3 +31,5 @@ spec:
               value: {{ .Values.persist.url }}
             - name: NANGO_ENTERPRISE
               value: "true"
+            - name: RUNNER_NODE_ID
+              value: {{ .Values.runner.nodeId | default "1" }}

--- a/charts/nango/values.yaml
+++ b/charts/nango/values.yaml
@@ -34,33 +34,35 @@ elasticsearch:
     elasticPassword: nango
 
 server:
-  name: server
+  name: nango-self-server
   replicas: 1
   useLoadBalancer: true
   MAILGUN_API_KEY: ""
   SERVER_PORT: "8080"
 
 jobs:
-  name: jobs
+  name: nango-self-jobs
   replicas: 1
   volume:
     name: flows-volume
     claimName: flow-claim
+    storageClassName: standard
     aws: false
     gcp: false
 
 runner:
-  name: runner
+  name: nango-self-runner
   url: http://nango-runner
   replicas: 1
+  nodeId: 1
 
 persist:
-  name: persist
+  name: nango-self-persist
   url: http://nango-persist
   replicas: 1
 
 orchestrator:
-  name: orchestrator
+  name: nango-self-orchestrator
   url: http://nango-orchestrator
   replicas: 1
 


### PR DESCRIPTION
- Bumped the chart version to 1.0.5
- added RUNNER_NODE_ID to the runner deployment
- prefixed all service names with `nango-self-` to mitigate conflicting environment variable names produced by Kubernetes
- Pointed `storageClassName` for jobs-pvc at new value that defaults to `standard`