### PR TITLE
fix: a few changes to make the helm chart work properly

### DIFF
--- a/charts/nango/Chart.yaml
+++ b/charts/nango/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: nango
 type: application
-version: 1.0.7
+version: 1.0.8
 appVersion: 0.0.2
 dependencies:
   - condition: postgresql.enabled

--- a/charts/nango/templates/server/server-deployment.yaml
+++ b/charts/nango/templates/server/server-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         - name: {{ .Values.server.name | default "nango-server" }}
           image: {{ .Values.shared.imageRegistry | default "nangohq" }}/{{ .Values.shared.imageRepository | default "nango" }}:{{ .Values.server.tag | default .Values.shared.tag }}
           imagePullPolicy: {{ .Values.imagePullPolicy  | default "Always" }}
-          args: ["node", "packages/server/dist/server.js"]
+          args: ["packages/server/entrypoint.sh]
           ports:
             - containerPort: {{ .Values.server.SERVER_PORT }}
           env:
@@ -58,9 +58,9 @@ spec:
             - name: NANGO_SERVER_URL
               value: {{ .Values.shared.NANGO_SERVER_URL }}
             - name: NANGO_PUBLIC_CONNECT_URL
-              value: {{ .Values.shared.NANGO_SERVER_URL }}
+              value: {{ .Values.shared.NANGO_PUBLIC_CONNECT_URL }}
             - name: FLAG_SERVE_CONNECT_UI
-              value: "true"
+              value: {{ .Values.shared.FLAG_SERVE_CONNECT_UI | default true | quote }}
             - name: NANGO_CALLBACK_URL
               value: {{ .Values.shared.NANGO_CALLBACK_URL }}
             - name: NODE_ENV

--- a/charts/nango/values.yaml
+++ b/charts/nango/values.yaml
@@ -80,9 +80,11 @@ shared:
   NANGO_DB_NAME: nango
   NANGO_DB_SSL: false
   NANGO_SERVER_URL: https://your-hosted-instance.com
+  NANGO_PUBLIC_CONNECT_URL: https://your-hosted-instance.com
   NANGO_CALLBACK_URL: https://your-hosted-instance.com/oauth/callback
   NANGO_LOGS_ENABLED: true
   NANGO_LOGS_ES_PWD: nango
   NANGO_LOGS_ES_URL: https://nango-elasticsearch.default.svc.cluster.local:9200
   NANGO_LOGS_ES_USER: elastic
+  FLAG_SERVE_CONNECT_UI: true
   tag: 6adbaf17e6cba479564277b1f5224f42558454f4 # 2025/02/10


### PR DESCRIPTION
- use `entrypoint.sh` as start script so that connect-ui can start in process
- allow`NANGO_PUBLIC_CONNECT_URL` to be configured separately to `NANGO_SERVER_URL` in values file
- bump version