### PR TITLE
feat: expand chart features with jobs service and service account for…

### DIFF
--- a/charts/nango/Chart.yaml
+++ b/charts/nango/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: nango
 type: application
-version: 1.0.9
+version: 1.1.0
 appVersion: 0.0.2
 dependencies:
   - condition: postgresql.enabled

--- a/charts/nango/templates/jobs/jobs-clusterrole.yaml
+++ b/charts/nango/templates/jobs/jobs-clusterrole.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.jobs.clusterAdmin }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.jobs.name | default "nango-jobs" }}-clusterrole
+  labels:
+    app: {{ .Values.jobs.name | default "nango-jobs" }}
+rules:
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["services", "pods", "configmaps", "secrets", "persistentvolumeclaims"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+{{- end }} 

--- a/charts/nango/templates/jobs/jobs-clusterrolebinding.yaml
+++ b/charts/nango/templates/jobs/jobs-clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.jobs.clusterAdmin }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.jobs.name | default "nango-jobs" }}-clusterrolebinding
+  labels:
+    app: {{ .Values.jobs.name | default "nango-jobs" }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.jobs.name | default "nango-jobs" }}-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.jobs.name | default "nango-jobs" }}-sa
+  namespace: {{ .Values.shared.namespace }}
+{{- end }} 

--- a/charts/nango/templates/jobs/jobs-deployment.yaml
+++ b/charts/nango/templates/jobs/jobs-deployment.yaml
@@ -13,6 +13,9 @@ spec:
       labels:
         app: {{ .Values.jobs.name | default "nango-jobs" }}
     spec:
+      {{- if .Values.jobs.clusterAdmin }}
+      serviceAccountName: {{ .Values.jobs.name | default "nango-jobs" }}-sa
+      {{- end }}
       {{- with .Values.shared.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -58,19 +61,25 @@ spec:
             - name: NODE_ENV
               value: {{ .Values.NODE_ENV | default "production" }}
             - name: NANGO_SERVER_URL
-              value: {{ .Values.shared.NANGO_SERVER_URL }}
+              value: {{ .Values.server.url }}
             - name: NANGO_ENTERPRISE
               value: "true"
             - name: NANGO_INTEGRATIONS_FULL_PATH
               value: {{ .Values.shared.flows_path }}
             - name: NANGO_RUNNER_PATH
               value: "/app/nango/packages/runner/dist/app.js"
+            - name: RUNNER_TYPE
+              value: {{ .Values.jobs.runnerType | default "LOCAL" }}
+            - name: RUNNER_OWNER_ID
+              value: {{ .Values.jobs.runnerOwnerId | default "nango-jobs" }}
             - name: PERSIST_SERVICE_URL
               value: {{ .Values.persist.url }}
             - name: RUNNER_SERVICE_URL
               value: {{ .Values.runner.url }}
             - name: ORCHESTRATOR_SERVICE_URL
               value: {{ .Values.orchestrator.url }}
+            - name: JOBS_SERVICE_URL
+              value: {{ .Values.jobs.url }}
             - name: NANGO_LOGS_ENABLED
               value: "{{ .Values.shared.NANGO_LOGS_ENABLED }}"
             - name: NANGO_LOGS_ES_PWD

--- a/charts/nango/templates/jobs/jobs-service.yaml
+++ b/charts/nango/templates/jobs/jobs-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ .Values.shared.namespace }}
+  name: {{ .Values.jobs.name | default "nango-jobs" }}
+spec:
+  type: NodePort
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3005
+  selector:
+    app: {{ .Values.jobs.name | default "nango-jobs" }}
+

--- a/charts/nango/templates/jobs/jobs-serviceaccount.yaml
+++ b/charts/nango/templates/jobs/jobs-serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.jobs.clusterAdmin }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.jobs.name | default "nango-jobs" }}-sa
+  namespace: {{ .Values.shared.namespace }}
+  labels:
+    app: {{ .Values.jobs.name | default "nango-jobs" }}
+{{- end }} 

--- a/charts/nango/values.yaml
+++ b/charts/nango/values.yaml
@@ -45,6 +45,7 @@ jobs:
   name: nango-self-jobs
   url: http://nango-self-jobs
   replicas: 1
+  clusterAdmin: false
   volume:
     name: flows-volume
     claimName: flow-claim

--- a/example-values.yaml
+++ b/example-values.yaml
@@ -71,6 +71,7 @@ server:
 jobs:
   name: nango-jobs
   replicas: 1
+  clusterAdmin: false
   volume:
     aws: true
 


### PR DESCRIPTION
- minor version bump
- added cluster role connected to service account for jobs deployment to be able to created deployments and services
- added jobs service to expose to runners
- made this optional with the use of `clusterAdmin` flag on values .