### PR TITLE
fix: add network policy permission to jobs cluster role

### DIFF
--- a/charts/nango/Chart.yaml
+++ b/charts/nango/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: nango
 type: application
-version: 1.1.2
+version: 1.1.3
 appVersion: 0.0.2
 dependencies:
   - condition: postgresql.enabled

--- a/charts/nango/templates/jobs/jobs-clusterrole.yaml
+++ b/charts/nango/templates/jobs/jobs-clusterrole.yaml
@@ -12,4 +12,7 @@ rules:
 - apiGroups: [""]
   resources: ["services", "pods", "configmaps", "secrets", "persistentvolumeclaims", "namespaces"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["networking.k8s.io"]
+  resources: ["networkpolicies"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 {{- end }} 


### PR DESCRIPTION
 Add network policy permissions to the jobs cluster role. This allows network policies to be created to constrain network permissions of runner pods.