### PR TITLE
Ross/nan 3680/add ssl env var

### DIFF
--- a/charts/nango/Chart.yaml
+++ b/charts/nango/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: nango
 type: application
-version: 1.1.4
+version: 1.1.5
 appVersion: 0.0.2
 dependencies:
   - condition: postgresql.enabled

--- a/charts/nango/templates/server/server-deployment.yaml
+++ b/charts/nango/templates/server/server-deployment.yaml
@@ -48,6 +48,8 @@ spec:
               value: "{{ .Values.shared.NANGO_DB_PORT | default 5432 }}"
             - name: NANGO_DB_SSL
               value: "{{ .Values.shared.NANGO_DB_SSL | default false }}"
+            - name: RECORDS_DATABASE_SSL
+              value: "{{ .Values.server.RECORDS_DATABASE_SSL | default false }}"
               {{- if .Values.shared.encryptionEnabled }}
             - name: NANGO_ENCRYPTION_KEY
               valueFrom:

--- a/charts/nango/values.yaml
+++ b/charts/nango/values.yaml
@@ -40,6 +40,7 @@ server:
   useLoadBalancer: true
   MAILGUN_API_KEY: ""
   SERVER_PORT: "8080"
+  RECORDS_DATABASE_SSL: true
 
 jobs:
   name: nango-self-jobs


### PR DESCRIPTION
Same as previously for the SSL for Orchestrator database, this needs to be added for the Records database.