### PR TITLE
Register the Unleash helm repo for chart-releaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,9 @@ jobs:
 
       - name: Add Helm Dependency Repos
         run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami 
+          helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo add airbyte https://airbytehq.github.io/helm-charts
+          helm repo add unleash https://docs.getunleash.io/helm-charts
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0


### PR DESCRIPTION
The chart-releaser release failed packaging `charts/nango` with:

```
Error: no repository definition for https://docs.getunleash.io/helm-charts
```

`chart-releaser` runs `helm dependency build`, which resolves dependency repos by URL. The new `unleash` subchart added in #32 points at `https://docs.getunleash.io/helm-charts`, but that repo wasn't registered